### PR TITLE
W3M - Switch from Google to Yahoo Finance

### DIFF
--- a/lib/wallstreet/w3m
+++ b/lib/wallstreet/w3m
@@ -19,7 +19,7 @@ PKG="wallstreet"
 
 [ -n "$TMDIR" ] || TMPDIR=$(mktemp -d /dev/shm/$PKG.XXXXXXXXX)
 trap "rm -rf $TMPDIR; pkill -f -9 lib/wallstreet/ >/dev/null 2>&1; exit" HUP INT QUIT TERM
-URL=http://google.com/finance
+URL=http://finance.yahoo.com/
 
 while true; do
 	w3m -dump "$URL" >$TMPDIR/finance 2>/dev/null


### PR DESCRIPTION
W3M widget no longer returning data post-regex, due to page changes for
text-based browsers - switched info provider from Google to Yahoo, and
now receiving similar output to before.