### PR TITLE
Fix a bug that prevented hollywood from exiting properly

### DIFF
--- a/bin/hollywood
+++ b/bin/hollywood
@@ -75,6 +75,7 @@ if [ -z "$TMUX" ]; then
 		tmux_launcher=tmux
 	fi
 	$tmux_launcher new-session -d -s $PKG "/bin/bash"
+	$tmux_launcher bind -n C-c kill-session
 	$tmux_launcher send-keys -t $PKG "$0 $1"
 	$tmux_launcher send-keys -t $PKG Enter
 	exec $tmux_launcher attach-session -t $PKG


### PR DESCRIPTION
Exiting hollywood was very difficult because you had to press Ctrl+C repeatedly or even hold it for multiple seconds and even then you got stuck in a tmux session most of the time. This PR fixes that.