### PR TITLE
snap: adjustments for hollywood

### DIFF
--- a/snap.hollywood/local/0001-apg.patch
+++ b/snap.hollywood/local/0001-apg.patch
@@ -1,0 +1,20 @@
+--- apg.orig	2020-02-16 00:22:11.159181623 -0300
++++ apg	2020-02-16 00:21:25.655813884 -0300
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-CONFFILE="/etc/apg.conf"
++CONFFILE="$SNAP/etc/apg.conf"
+ 
+ # wrapper to give default parameters to apg if invoked without
+ 
+@@ -9,7 +9,7 @@
+   if [ -e "$CONFFILE" ]; then
+     . $CONFFILE
+   fi
+-  /usr/lib/apg/apg $APG_PARM
++  "$SNAP/usr/lib/apg/apg" $APG_PARM
+ else
+-  /usr/lib/apg/apg $@
++  "$SNAP/usr/lib/apg/apg" $@
+ fi

--- a/snap.hollywood/local/0002-byobu-shm.patch
+++ b/snap.hollywood/local/0002-byobu-shm.patch
@@ -1,0 +1,20 @@
+--- dirs.orig	2020-02-16 00:18:13.938669957 -0300
++++ dirs	2020-02-16 00:20:06.556951542 -0300
+@@ -49,7 +49,7 @@
+ # Create and export the runtime cache directory
+ if [ -w /dev/shm ]; then
+ 	# Use shm for performance, if possible
+-	for i in /dev/shm/$PKG-$USER-*; do
++	for i in /dev/shm/snap.$SNAP_NAME.$USER/*; do
+ 		if [ -d "$i" ] && [ -O "$i" ]; then
+ 			export BYOBU_RUN_DIR="$i"
+ 			break
+@@ -57,7 +57,7 @@
+ 	done
+ 	# Still empty, make a new one
+ 	if [ ! -d "$BYOBU_RUN_DIR" ] || [ ! -O "$BYOBU_RUN_DIR" ]; then
+-		export BYOBU_RUN_DIR=$(mktemp -d /dev/shm/$PKG-$USER-XXXXXXXX)
++		export BYOBU_RUN_DIR=$(mktemp -d /dev/shm/snap.$SNAP_NAME.$USER/XXXXXXXX)
+ 	fi
+ fi
+ if [ ! -d "$BYOBU_RUN_DIR" ] || [ ! -O "$BYOBU_RUN_DIR" ] || [ ! -w "$BYOBU_RUN_DIR" ]; then

--- a/snap.hollywood/local/0003-hexdump.patch
+++ b/snap.hollywood/local/0003-hexdump.patch
@@ -1,0 +1,13 @@
+--- hexdump.orig	2020-02-16 10:01:00.332202757 -0300
++++ hexdump	2020-02-16 10:01:30.707334337 -0300
+@@ -19,8 +19,8 @@
+ 
+ trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" HUP INT QUIT TERM
+ while true; do
+-	for f in $(ls /usr/bin/ | sort -R); do
+-		head -c 4096 "/usr/bin/$f" | hexdump -C | ccze -A -c default=green -c dir="bold green"
++	for f in $(ls "$SNAP/usr/bin/" | sort -R); do
++		head -c 4096 "$SNAP/usr/bin/$f" | hexdump -C | ccze -A -c default=green -c dir="bold green"
+ 		sleep 0.7
+ 	done
+ done

--- a/snap.hollywood/local/0004-man.patch
+++ b/snap.hollywood/local/0004-man.patch
@@ -1,0 +1,11 @@
+--- /snap/hollywood/current/usr/lib/hollywood/man.orig	2016-05-09 21:33:50.000000000 -0300
++++ /snap/hollywood/current/usr/lib/hollywood/man	2020-02-16 14:25:13.000000000 -0300
+@@ -19,7 +19,7 @@
+ 
+ trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" HUP INT QUIT TERM
+ while true; do
+-	FILES=$(ls /usr/share/man/man1/ | sort -R | sed "s/\.1\.gz.*$//" | head -n 4096)
++	FILES=$(ls "$SNAP/usr/share/man/man1/" | sort -R | sed "s/\.1\.gz.*$//" | head -n 4096)
+ 	for f in $FILES; do
+ 		man "$f" | ccze -A
+ 		sleep 0.2

--- a/snap.hollywood/local/setup
+++ b/snap.hollywood/local/setup
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+ccze_plugin_dir="$HOME/.ccze"
+
+# Workaround hardcoded paths in ccze. Link to the confined HOME.
+if [ ! -d "$ccze_plugin_dir" ] ; then
+    if [ -L "$ccze_plugin_dir" ]; then
+        rm "$ccze_plugin_dir"
+    fi
+    ln -s "$SNAP/usr/lib/ccze" "$HOME/.ccze"
+fi
+
+byoburc="$HOME/.byoburc"
+# Workaround BYOBU_PREFIX using realpath which does not work
+# well for a constantly changing symlink.
+if [ -f "$byoburc"  ] && ! grep $(realpath "$SNAP") "$byoburc" ; then
+    rm "$byoburc"
+fi
+
+exec "$@"

--- a/snap.hollywood/snapcraft.yaml
+++ b/snap.hollywood/snapcraft.yaml
@@ -1,23 +1,60 @@
 name: hollywood
-version: 1.13
+base: core18
+version: "1.13"
 summary: fill your console with Hollywood melodrama technobabble
 description: >
     This utility will split your console into a multiple panes of genuine
     technobabble, perfectly suitable for any Hollywood geek melodrama.
     It is particularly suitable on any number of computer consoles in the
     background of any excellent schlock technothriller.
-confinement: classic
+confinement: strict
 grade: stable
 
 parts:
+  setup:
+    plugin: dump
+    source: snap/local
+    prime:
+      - setup
+
   hollywood:
     plugin: nil
-    stage-packages: [hollywood]
-    stage:
-        - -bin/hollywood
-    snap:
-        - -bin/hollywood
+    build-packages:
+      - patch
+    stage-packages:
+      - coreutils
+      - iproute2
+      - hollywood
+      - man-db
+    override-build: |
+      snapcraftctl build
+      # patch apg hardcoded paths
+      patch -s -b "$SNAPCRAFT_PART_INSTALL/usr/bin/apg" "$SNAPCRAFT_STAGE/0001-apg.patch"
+      patch -s -b "$SNAPCRAFT_PART_INSTALL/usr/lib/byobu/include/dirs" "$SNAPCRAFT_STAGE/0002-byobu-shm.patch"
+      patch -s -b "$SNAPCRAFT_PART_INSTALL/usr/lib/hollywood/hexdump" "$SNAPCRAFT_STAGE/0003-hexdump.patch"
+      patch -s -b "$SNAPCRAFT_PART_INSTALL/usr/lib/hollywood/man" "$SNAPCRAFT_STAGE/0004-man.patch"
+    organize:
+      usr/lib/$SNAPCRAFT_ARCH_TRIPLET/ccze: usr/lib/ccze
+    prime:
+      - -**/*.orig
+    after:
+      - setup
+
+environment:
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
+  LD_LIBRARY_PATH: $SNAP/usr/lib/man-db
+  MAN_TEST_DISABLE_SYSTEM_CONFIG: 1
+  MANPATH: $SNAP/usr/share/man
+  GROFF_FONT_PATH: $SNAP/usr/share/groff/current/font
+  GROFF_TMAC_PATH: $SNAP/usr/share/groff/current/tmac
 
 apps:
    hollywood:
-     command: hollywood
+     plugs:
+       - network-bind
+       - network-observe
+       - system-observe
+     command-chain:
+       - setup
+     command: usr/bin/hollywood


### PR DESCRIPTION
- Use base: core18
- Move to strict confinement
- Patch agp to be snap-aware
- Patch 3 hollywood files to be snap-aware:
  - /dev/shm path
  - man related path
  - paths for hexdump
- Add command-chain for minor workarounds:
  - BYOBU_PREFIX uses realpath in .byoburc
  - Link czze plugins to the confined home

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

---

I would personally merge hollywood and wallstreet into one snap and have the Snap Store create an alias for wallstreet (to no have to call hollywood.wallstreet) and have just 1 `snap` directory.
Regardless, I would `git mv snap.hollywood snap` and hook up with https://build.snapcaft.io for automatic builds.

To build you will need the latest snapcraft from the stable channel from https://snapcraft.io/snapcraft and to make use of lxd you can call it like `snapcraft --use-lxd`.

TODO (if ok with):
- use this here source instead of the hollywood `stage-packages` entry.
- add support for an alternate sysroot for lib/hollywood and remove these here patches.
