### PR TITLE
do not use hardcoded bash path

### DIFF
--- a/bin/hollywood
+++ b/bin/hollywood
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # N.B.: Use bash for $RANDOM
 #
 # hollywood: create a hollywood suitable consoles of tech geekery
@@ -74,7 +74,7 @@ if [ -z "$TMUX" ]; then
 	else
 		tmux_launcher=tmux
 	fi
-	$tmux_launcher new-session -d -s $PKG "/bin/bash"
+	$tmux_launcher new-session -d -s $PKG "bash"
 	$tmux_launcher send-keys -t $PKG "$0 $1"
 	$tmux_launcher send-keys -t $PKG Enter
 	exec $tmux_launcher attach-session -t $PKG

--- a/bin/wallstreet
+++ b/bin/wallstreet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # N.B.: Use bash for $RANDOM
 #
 # wallstreet: create wallstreet suitable consoles of news nerdery
@@ -42,7 +42,7 @@ if [ -z "$TMUX" ]; then
 	else
 		tmux_launcher=tmux
 	fi
-	$tmux_launcher new-session -d -s $PKG "/bin/bash"
+	$tmux_launcher new-session -d -s $PKG "bash"
 	$tmux_launcher send-keys -t $PKG "$0 $1"
 	$tmux_launcher send-keys -t $PKG Enter
 	exec $tmux_launcher attach-session -t $PKG

--- a/lib/hollywood/code
+++ b/lib/hollywood/code
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014 Dustin Kirkland <dustin.kirkland@gmail.com>
 #

--- a/lib/hollywood/jp2a
+++ b/lib/hollywood/jp2a
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014 Dustin Kirkland <dustin.kirkland@gmail.com>
 #

--- a/lib/hollywood/mplayer
+++ b/lib/hollywood/mplayer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014 Dustin Kirkland <dustin.kirkland@gmail.com>
 #

--- a/lib/wallstreet/img2txt
+++ b/lib/wallstreet/img2txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 Dustin Kirkland <dustin.kirkland@gmail.com>
 #

--- a/lib/wallstreet/jp2a
+++ b/lib/wallstreet/jp2a
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 Dustin Kirkland <dustin.kirkland@gmail.com>
 #

--- a/lib/wallstreet/rsstail
+++ b/lib/wallstreet/rsstail
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 Dustin Kirkland <dustin.kirkland@gmail.com>
 #


### PR DESCRIPTION
This avoids using a hardcoded path for bash to allow the scripts to run on systems where bash is not located at `/bin/bash`, e.g. NixOS.