### PR TITLE
Use find instead of locate

### DIFF
--- a/lib/hollywood/code
+++ b/lib/hollywood/code
@@ -14,17 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-command -v locate >/dev/null 2>&1 || exit 1
-command -v view >/dev/null 2>&1 || exit 1
+command -v find >/dev/null 2>&1 || exit 1
+command -v pygmentize >/dev/null 2>&1 || exit 1
 
 trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" INT
 while true; do
-	FILES=$(locate -l 4096 "/usr/*.java" "/usr/*.c" "/usr/*.cpp" 2>/dev/null | sort -R)
-	for f in $FILES; do
-		[ -r "$f" ] || continue
-		[ -s "$f" ] || continue
-		[ -f "$f" ] || continue
-		pygmentize "$f" 2>/dev/null || true
-		sleep 2
-	done
+	find /usr -readable -size +0 -type f -name \*.java -o -name \*.c -o -name \*.cpp -exec pygmentize "{}" \; -exec sleep 2 \; 2>/dev/null
 done

--- a/lib/hollywood/jp2a
+++ b/lib/hollywood/jp2a
@@ -14,18 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-command -v locate >/dev/null 2>&1 || exit 1
+command -v find >/dev/null 2>&1 || exit 1
 command -v jp2a >/dev/null 2>&1 || exit 1
 
 trap "pkill -f -9 lib/hollywood/ >/dev/null 2>&1; exit" INT
 while true; do
-	FILES=$(locate -l 4096 "/usr/*jpg" 2>/dev/null | sort -R)
-	for f in $FILES; do
-		[ -r "$f" ] || continue
-		[ -s "$f" ] || continue
-		[ -f "$f" ] || continue
-		clear
-		jp2a --colors --term-fit "$f"
-		sleep 0.57
-	done
+	find /usr -readable -size +0 -type f -name \*.jpg -exec jp2a --colors --term-fit "{}" \; -exec sleep 0.57 \; -exec clear \; 2>/dev/null
 done


### PR DESCRIPTION
On some systems, the locate database is empty, or disabled, resulting in empty output of code and jp2a:

```
locate: can not stat () `/var/lib/mlocate/mlocate.db': No such file or directory
```

This change uses `find` instead, which works always.
Drawback : there is no limit of items. We could add `-maxdepth` but it wouldn't have the same effect