### PR TITLE
Change the dsa key type in the key generation command to ed25519.

### DIFF
--- a/lib/hollywood/sshart
+++ b/lib/hollywood/sshart
@@ -24,7 +24,7 @@ while true; do
 	mkdir -p "$tmpdir"
 	tmpfile=$(mktemp -p "$tmpdir" -t XXXXXX)
 	rm -f $tmpfile
-	art=$(ssh-keygen -vvv -b 1024 -t dsa -N "" -f $tmpfile)
+	art=$(ssh-keygen -vvv -b 1024 -t ed25519 -N "" -f $tmpfile)
 	rm -f $tmpfile $tmpfile.pub
 	wait
 	clear


### PR DESCRIPTION
Since the DSA key type is no longer supported in ssh-keygen (resulting in the 'unknown key type dsa' error), it has been replaced with ed25519.